### PR TITLE
Major Refactor WIP - Highlighting MediaListItem upon AudioTrack Selection/Change/Update

### DIFF
--- a/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/components/MediaListItem.kt
+++ b/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/components/MediaListItem.kt
@@ -5,6 +5,7 @@ package com.seebaldtart.projectmusicplayer.ui.components
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -17,12 +18,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -30,10 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -48,23 +49,41 @@ import kotlin.jvm.optionals.getOrNull
 
 @Composable
 fun AudioTrackListItem (
+    id: Long,
     title: String,
     artist: String,
     album: String,
     duration: Int,
     imageState: State<Optional<Bitmap>>,
+    selectedIDState: State<Long>,
     onAudioTrackSelected: () -> Unit,
     onViewShown: () -> Unit
 ) {
     PROJECTMusicPlayerTheme {
+        val selectedID by selectedIDState
+        val selectedBackground = R.color.colorPrimary
+        val unSelectedBackground = android.R.color.transparent
+        val background by remember(selectedID) {
+            mutableIntStateOf(
+                if (selectedID == id) {
+                    selectedBackground
+                } else {
+                    unSelectedBackground
+                }
+            )
+        }
+
         Row(
             modifier = Modifier
                 .height(dimensionResource(R.dimen.list_item_height))
                 .fillMaxWidth()
+                .background(colorResource(background))
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = LocalIndication.current,
-                    onClick = { onAudioTrackSelected.invoke() }
+                    onClick = {
+                        onAudioTrackSelected.invoke()
+                    }
                 )
                 .padding(bottom = 1.dp)
         ) {
@@ -159,11 +178,13 @@ fun AudioTrackListItem (
 fun AudioTrackItem_Preview() {
     PROJECTMusicPlayerTheme {
         AudioTrackListItem(
-            "Title",
-            "Artist",
-            "Album",
-            300,
+            id = -1,
+            title = "Title",
+            artist = "Artist",
+            album = "Album",
+            duration = 300,
             imageState = remember { mutableStateOf(Optional.empty<Bitmap>()) },
+            selectedIDState = remember { mutableLongStateOf(-1) },
             onAudioTrackSelected = {},
             onViewShown = {}
         )

--- a/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/components/MediaPlayerController.kt
+++ b/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/components/MediaPlayerController.kt
@@ -5,7 +5,6 @@ package com.seebaldtart.projectmusicplayer.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,7 +23,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,9 +42,6 @@ import androidx.compose.ui.unit.dp
 import com.seebaldtart.projectmusicplayer.R
 import com.seebaldtart.projectmusicplayer.ui.theme.PROJECTMusicPlayerTheme
 import com.seebaldtart.projectmusicplayer.utils.MediaPlayerUtils
-import java.text.DecimalFormat
-import java.text.NumberFormat
-import java.util.Locale
 
 @Composable
 fun MediaPlayerController(
@@ -67,7 +70,9 @@ fun MediaPlayerController(
                 ) {
                     Spacer(Modifier.weight(spacerWeight, fill = true))
 
-                    Column(modifier = Modifier.weight(weight = 6F, fill = true)) {
+                    Column(
+                        modifier = Modifier.weight(weight = 6F, fill = true)
+                    ) {
                         val totalDuration by selectedTrackDuration
                         val playTimeProgressState by playTimeProgress
                         var seekbarUpdate by remember { mutableFloatStateOf(0F) }

--- a/app/src/main/java/com/seebaldtart/projectmusicplayer/viewmodels/AudioPlayListViewModel.kt
+++ b/app/src/main/java/com/seebaldtart/projectmusicplayer/viewmodels/AudioPlayListViewModel.kt
@@ -36,8 +36,7 @@ class AudioPlayListViewModel @Inject constructor(
     private val groupSelection = MutableStateFlow<Optional<AudioSelectionData>>(Optional.empty())
 
     /** The [StateFlow] for the currently selected [AudioTrack] */
-    val selectedTrack: StateFlow<Optional<AudioTrack>>
-        get() = currentlySelectedTrack.asStateFlow()
+    val selectedTrack: StateFlow<Optional<AudioTrack>> = currentlySelectedTrack.asStateFlow()
     /** The [StateFlow] for the currently selected [AudioTrackFilter] */
     val trackFilters: StateFlow<AudioTrackFilter>
         get() = selectedTrackFilter.asStateFlow()
@@ -49,8 +48,8 @@ class AudioPlayListViewModel @Inject constructor(
     fun stream(): StateFlow<List<AudioTrack>> = repository.stream()
 
     /** Calling this method will notify the ViewModel that a specific [AudioTrack] and should be played. */
-    fun onAudioTrackSelected(track: AudioTrack) {
-        currentlySelectedTrack.update { Optional.of(track) }
+    fun onAudioTrackSelected(track: AudioTrack?) {
+        currentlySelectedTrack.update { Optional.ofNullable(track) }
     }
 
     /** Calling this method will display all [AudioTrack]s, grouped by their [GroupSelectionState]. */


### PR DESCRIPTION
Goals:
- Code cleanup to better reflect current code quality
- Mirror the older version's UI and functionality as much as possible
- Refactor app project to utilize Kotlin, Coroutines, Jetpack Compose, Hilt/Dagger, etc.

Updates:
- Now highlighting MediaListItem upon audio track selection/change/update

Notes/TODO:
- Core media player logic functionality has been implemented
- Core audio selection functionality has been implemented
- Core permission-check functionality has been implemented
- Core limited media retrieval functionality has been implemented
- Need to implement toolbar/top bar
- Need to implement navigation to Now Playing screen
- Need to utilize fragments in single activity for audio selection functionality
- [Nice to have] Need to implement loop functionality
- [Nice to have] Need to implement audio list items filtering
- Consider segregating MediaPlayer implementation, state and functionality out MusicPlayerStateViewModel and into a "MediaPlayerService"
- Rename MusicPlayer___.kt files to MediaPlayer___.kt
- Finish cleaning up/removing old code

Known Bugs:
- ContentResolver appears to only be retrieving audio files from internal storage, not SDCard - even when referencing external URI path (uncommenting the internal URI portion will retrieve notification and ringtone files)
- [Warning - Watch-Item] MusicPlayerStateViewModel MediaPlayer state handling is 'delicate'. I have seen ANRs due to mishandling (probably due to the 'nowPlayingTrackProgress' while-loop?). Keeping this note as a watch-item.
- Slider's progress bar (thumb) not tracking user's continuous input - instead, it only updates after motion release