### PR TITLE
Major Refactor WIP - Bug fix: Media Player Controller's playlist refreshing upon returning back to AudioPlayListSelectionFragment

### DIFF
--- a/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/fragments/AudioPlayListFragment.kt
+++ b/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/fragments/AudioPlayListFragment.kt
@@ -70,22 +70,6 @@ class AudioPlayListFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
-//                mediaPlayerViewModel.setDelegate(object : MediaPlayerStateViewModel.Delegate {
-//                    override fun onTrackAutomaticallyUpdated(track: AudioTrack?) {
-//                        viewModel.onAudioTrackSelected(track)
-//                    }
-//
-//                    override fun onError(error: PlaybackError) {
-//                        // TODO: Display a Toast or SnackBar
-//                        val message = "Playback Error: $error"
-//                        Log.e(
-//                            this@AudioPlayListFragment::class.simpleName,
-//                            message,
-//                            RuntimeException(message)
-//                        )
-//                    }
-//                })
-
                 PROJECTMusicPlayerTheme {
                     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
                     Scaffold(
@@ -114,6 +98,7 @@ class AudioPlayListFragment : Fragment() {
                                 onAudioTrackSelected = { track ->
                                     viewModel.onAudioTrackSelected(track)
                                     mediaPlayerViewModel.onAudioTrackSelected(track)
+                                    mediaPlayerViewModel.setCurrentPlaylist(viewModel.selectedPlayListState.value)
                                     mediaPlayerViewModel.onPlayClicked(requireContext())
                                 },
                                 onAudioTrackShown = viewModel::loadThumbnailsForTrack

--- a/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/fragments/AudioPlayListSelectionFragment.kt
+++ b/app/src/main/java/com/seebaldtart/projectmusicplayer/ui/fragments/AudioPlayListSelectionFragment.kt
@@ -77,9 +77,7 @@ import com.seebaldtart.projectmusicplayer.ui.theme.PROJECTMusicPlayerTheme
 import com.seebaldtart.projectmusicplayer.viewmodels.AudioPlayListViewModel
 import com.seebaldtart.projectmusicplayer.viewmodels.MediaPlayerStateViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlin.jvm.optionals.getOrNull
 
 @AndroidEntryPoint
@@ -110,14 +108,11 @@ class AudioPlayListSelectionFragment : Fragment() {
                             RuntimeException(message)
                         )
                     }
-                })
 
-                LaunchedEffect(true) {
-                    viewModel.stream()
-                        .onEach {
-                            mediaPlayerViewModel.setCurrentPlaylist(it)
-                        }.collect()
-                }
+                    override fun onRequestPlayList(): List<AudioTrack> {
+                        return viewModel.selectedPlayListState.value
+                    }
+                })
 
                 PROJECTMusicPlayerTheme {
                     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
@@ -144,6 +139,7 @@ class AudioPlayListSelectionFragment : Fragment() {
                                 onAudioTrackSelected = { track ->
                                     viewModel.onAudioTrackSelected(track)
                                     mediaPlayerViewModel.onAudioTrackSelected(track)
+                                    mediaPlayerViewModel.setCurrentPlaylist(viewModel.selectedPlayListState.value)
                                     mediaPlayerViewModel.onPlayClicked(requireContext())
                                 },
                                 onAudioTrackShown = viewModel::loadThumbnailsForTrack,


### PR DESCRIPTION
Goals:
- Code cleanup to better reflect current code quality
- Mirror the older version's UI and functionality as much as possible
- Refactor app project to utilize Kotlin, Coroutines, Jetpack Compose, Hilt/Dagger, etc.

Updates:
- Bug fix: Media Player Controller's playlist refreshing upon returning back to AudioPlayListSelectionFragment, even without selecting new audio or playlist

Notes/TODO:
- ✅ Core media player logic functionality has been implemented
- ✅ Core audio selection functionality has been implemented
- ✅ Core permission-check functionality has been implemented
- ✅ Core limited media retrieval functionality has been implemented
- ✅ Need to implement toolbar/top bar
- Need to implement navigation to Now Playing screen
- ✅ Need to utilize fragments in single activity for audio selection functionality
- [Nice to have] Need to implement loop functionality
- [Nice to have] Need to implement audio list items filtering
- Consider segregating MediaPlayer implementation, state and functionality out MusicPlayerStateViewModel and into a "MediaPlayerService"
- ✅ Rename MusicPlayer___.kt files to MediaPlayer___.kt
- Finish cleaning up/removing old code

Known Bugs:
- ContentResolver appears to only be retrieving audio files from internal storage, not SDCard - even when referencing external URI path (uncommenting the internal URI portion will retrieve notification and ringtone files)
- [Warning - Watch-Item] MusicPlayerStateViewModel MediaPlayer state handling is 'delicate'. I have seen ANRs due to mishandling (probably due to the 'nowPlayingTrackProgress' while-loop?). Keeping this note as a watch-item.
- Slider's progress bar (thumb) not tracking user's continuous input - instead, it only updates after motion release